### PR TITLE
Align service creation with backend API

### DIFF
--- a/frontend/src/app/(protected)/services/page.tsx
+++ b/frontend/src/app/(protected)/services/page.tsx
@@ -6,63 +6,13 @@ import { StatsCard } from "@/components/service/StatsCard";
 import { Button } from "@/components/ui/button";
 import { createService, fetchServices, updateServiceStatus } from "@/lib/api";
 import { CreateServiceData } from "@/schemas/serviceSchema";
-import { Service } from "@/types/Service";
+import { Service, CreateServicePayload } from "@/types/Service";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle, Plus, Settings, Users } from "lucide-react";
-import { useState } from "react";
-const mockServices: Service[] = [
-  {
-    id: "1",
-    name: "Générateur de Résumés",
-    description: "Service de résumé automatique de documents",
-    category: "Traitement de texte",
-    status: "active",
-    agent: "Assistant Client",
-    model: "gpt-4",
-    lastUsed: "Il y a 30 minutes",
-    usageCount: 156,
-    isPublic: true,
-  },
-  {
-    id: "2",
-    name: "Analyseur de Sentiment",
-    description: "Analyse des sentiments dans les commentaires clients",
-    category: "Analyse",
-    status: "active",
-    agent: "Générateur de Contenu",
-    model: "gpt-3.5-turbo",
-    lastUsed: "Il y a 2 heures",
-    usageCount: 89,
-    isPublic: false,
-  },
-  {
-    id: "3",
-    name: "Correcteur Orthographique",
-    description: "Correction automatique de textes",
-    category: "Traitement de texte",
-    status: "testing",
-    agent: "Analyseur de Code",
-    model: "claude-3",
-    lastUsed: "Il y a 1 jour",
-    usageCount: 23,
-    isPublic: false,
-  },
-  {
-    id: "4",
-    name: "Traducteur Multilingue",
-    description: "Service de traduction automatique",
-    category: "Traduction",
-    status: "inactive",
-    agent: "Assistant Client",
-    model: "gpt-4",
-    lastUsed: "Il y a 3 jours",
-    usageCount: 67,
-    isPublic: true,
-  },
-];
+import { useState, useEffect } from "react";
 
 export default function ServicesPage() {
-  const [services, setServices] = useState<Service[]>(mockServices);
+  const [services, setServices] = useState<Service[]>([]);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const queryClient = useQueryClient();
 
@@ -70,6 +20,24 @@ export default function ServicesPage() {
     queryKey: ["services"],
     queryFn: fetchServices,
   });
+
+  useEffect(() => {
+    if (ServicesFromDb) {
+      const mapped = ServicesFromDb.map((s) => ({
+        id: s.id,
+        name: s.name,
+        description: s.description || "",
+        category: s.category || "",
+        status: s.isActive ? "active" : "inactive",
+        agent: "",
+        model: "",
+        lastUsed: "",
+        usageCount: 0,
+        isPublic: false,
+      }));
+      setServices(mapped);
+    }
+  }, [ServicesFromDb]);
 
   const { mutate: newService } = useMutation({
     mutationFn: createService,
@@ -95,7 +63,14 @@ export default function ServicesPage() {
   const publicServices = services.filter((s) => s.isPublic).length;
 
   const handleCreateService = (serviceData: CreateServiceData) => {
-    newService(serviceData);
+    const payload: CreateServicePayload = {
+      title: serviceData.name,
+      description: serviceData.description,
+      category: serviceData.category,
+      organizationId: serviceData.organizationId,
+      price: serviceData.price,
+    };
+    newService(payload);
   };
 
   const handleStatusChange = (serviceId: string, status: Service["status"]) => {

--- a/frontend/src/components/service/CreateServiceModal.tsx
+++ b/frontend/src/components/service/CreateServiceModal.tsx
@@ -46,6 +46,8 @@ export function CreateServiceModal({
       name: "",
       description: "",
       category: "",
+      organizationId: "",
+      price: 0,
       agent: "",
       model: "",
       inputs: [{ name: "", type: "text", description: "", required: true }],
@@ -92,7 +94,7 @@ export function CreateServiceModal({
   const getFieldsForStep = (step: number): (keyof CreateServiceData)[] => {
     switch (step) {
       case 0:
-        return ["name", "description", "category"];
+        return ["name", "description", "category", "organizationId", "price"];
       case 1:
         return ["agent", "model"];
       case 2:

--- a/frontend/src/components/service/ServiceBasicInfoForm.tsx
+++ b/frontend/src/components/service/ServiceBasicInfoForm.tsx
@@ -31,6 +31,7 @@ export function ServiceBasicInfoForm() {
     watch,
   } = useFormContext<CreateServiceData>();
   const category = watch("category");
+  const price = watch("price");
 
   return (
     <div className="space-y-4">
@@ -80,6 +81,34 @@ export function ServiceBasicInfoForm() {
         </Select>
         {errors.category && (
           <p className="text-sm text-red-600 mt-1">{errors.category.message}</p>
+        )}
+      </div>
+
+      <div>
+        <Label htmlFor="organizationId">ID de l'organisation</Label>
+        <Input
+          id="organizationId"
+          {...register("organizationId")}
+          placeholder="UUID de l'organisation"
+        />
+        {errors.organizationId && (
+          <p className="text-sm text-red-600 mt-1">
+            {errors.organizationId.message}
+          </p>
+        )}
+      </div>
+
+      <div>
+        <Label htmlFor="price">Prix</Label>
+        <Input
+          id="price"
+          type="number"
+          step="0.01"
+          {...register("price", { valueAsNumber: true })}
+          placeholder="Prix du service"
+        />
+        {errors.price && (
+          <p className="text-sm text-red-600 mt-1">{errors.price.message}</p>
         )}
       </div>
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,7 +8,7 @@ import {
   RegisterResponse,
   User,
 } from "@/types/Auth";
-import { Service } from "@/types/Service";
+import { Service, CreateServicePayload } from "@/types/Service";
 import {
   Agent,
   CreateAgentPayload,
@@ -66,9 +66,9 @@ export const fetchServices = async (): Promise<Service[]> => {
 };
 
 export const createService = async (
-    serviceData: Service
+    serviceData: CreateServicePayload
 ): Promise<Service> => {
-  return await nestAPI.post<Service, Service>("/services", serviceData);
+  return await nestAPI.post<CreateServicePayload, Service>("/services", serviceData);
 };
 
 export const updateServiceStatus = async (

--- a/frontend/src/schemas/serviceSchema.ts
+++ b/frontend/src/schemas/serviceSchema.ts
@@ -10,6 +10,12 @@ export const serviceBasicInfoSchema = z.object({
     .min(1, "La description est requise")
     .max(500, "La description ne peut pas dépasser 500 caractères"),
   category: z.string().min(1, "La catégorie est requise"),
+  organizationId: z
+    .string()
+    .min(1, "L'organisation est requise"),
+  price: z
+    .number({ invalid_type_error: "Le prix doit être un nombre" })
+    .positive("Le prix doit être positif"),
 });
 
 export const serviceAgentSchema = z.object({

--- a/frontend/src/types/Service.ts
+++ b/frontend/src/types/Service.ts
@@ -3,12 +3,12 @@ export interface Service {
   name: string;
   description: string;
   category: string;
-  status: "active" | "inactive" | "testing";
-  agent: string;
-  model: string;
-  lastUsed: string;
-  usageCount: number;
-  isPublic: boolean;
+  status?: "active" | "inactive" | "testing";
+  agent?: string;
+  model?: string;
+  lastUsed?: string;
+  usageCount?: number;
+  isPublic?: boolean;
 }
 
 export interface Agent {
@@ -31,4 +31,13 @@ export interface ServiceOutput {
   name: string;
   type: "text" | "json" | "file";
   description?: string;
+}
+
+export interface CreateServicePayload {
+  title: string;
+  description?: string;
+  category?: string;
+  organizationId: string;
+  price: number;
+  authorId?: string;
 }


### PR DESCRIPTION
## Summary
- sync service types with backend models
- extend service schema with organization and price
- update creation modal and basic info form to use new fields
- map fetched services to UI cards
- adjust API client to send backend payload

## Testing
- `npm --prefix backend test` *(fails: jest not found)*
- `npm --prefix frontend run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dd34d1fe0832ea3a391f51515b48b