### PR TITLE
Update service DTO name field and require author

### DIFF
--- a/backend/src/service/dto/create-service.dto.ts
+++ b/backend/src/service/dto/create-service.dto.ts
@@ -8,7 +8,7 @@ export class CreateServiceDto {
     })
     @IsString()
     @IsNotEmpty()
-    title: string;
+    name: string;
 
     @ApiPropertyOptional({
         description: 'Description du service'
@@ -33,14 +33,13 @@ export class CreateServiceDto {
     @IsNotEmpty()
     organizationId: string;
 
-    @ApiPropertyOptional({
-        description: 'ID de l\'auteur (user système par défaut)',
-        example: '1',
-        default: '1'
+    @ApiProperty({
+        description: 'ID de l\'auteur',
+        example: '123e4567-e89b-12d3-a456-426614174001'
     })
     @IsString()
-    @IsOptional()
-    authorId?: string;
+    @IsNotEmpty()
+    authorId: string;
 
     @ApiProperty({
         description: 'Prix du service',

--- a/backend/src/service/service.controller.ts
+++ b/backend/src/service/service.controller.ts
@@ -39,7 +39,7 @@ export class ServiceController {
       basic: {
         summary: 'Création basique',
         value: {
-          title: 'Service de traduction',
+          name: 'Service de traduction',
           description: 'Traduction professionnelle',
           organizationId: '123e4567-e89b-12d3-a456-426614174000',
           authorId: '123e4567-e89b-12d3-a456-426614174001',
@@ -49,7 +49,7 @@ export class ServiceController {
       full: {
         summary: 'Création complète',
         value: {
-          title: 'Service de traduction premium',
+          name: 'Service de traduction premium',
           description: 'Traduction professionnelle avec relecture',
           category: 'traduction',
           organizationId: '123e4567-e89b-12d3-a456-426614174000',
@@ -94,7 +94,7 @@ export class ServiceController {
       example: {
         statusCode: 400,
         message: [
-          'title should not be empty',
+          'name should not be empty',
           'price must be a number'
         ],
         error: 'Bad Request'

--- a/backend/src/service/service.service.ts
+++ b/backend/src/service/service.service.ts
@@ -13,7 +13,7 @@ export class ServiceService {
     ) {}
 
     async create(createServiceDto: CreateServiceDto) {
-        const { title, description, category, organizationId, authorId, price } = createServiceDto;
+        const { name, description, category, organizationId, authorId, price } = createServiceDto;
 
         const serviceConfig = await this.prisma.serviceConfig.create({
             data: {
@@ -32,12 +32,13 @@ export class ServiceService {
 
         return this.prisma.service.create({
             data: {
-                name: title,
+                name,
                 slug: `service-${Date.now()}`,
                 description,
                 category: category || 'default',
                 config: { connect: { id: serviceConfig.id } },
-                createdBy: { connect: { id: authorId } }
+                createdBy: { connect: { id: authorId } },
+                organizationId
             },
             include: {
                 config: true,


### PR DESCRIPTION
## Summary
- rename `title` property to `name` in `CreateServiceDto`
- require `authorId` in new service creation
- update controller examples for new field
- store `organizationId` on the created `Service`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dde92e940832e844bef874761a28a